### PR TITLE
Use parentheses to avoid warnings during compilation in elixir 1.17

### DIFF
--- a/lib/grpc/server.ex
+++ b/lib/grpc/server.ex
@@ -47,7 +47,7 @@ defmodule GRPC.Server do
       codecs = opts[:codecs] || [GRPC.Codec.Proto]
       compressors = opts[:compressors] || []
 
-      Enum.each(service_mod.__rpc_calls__, fn {name, _, _} = rpc ->
+      Enum.each(service_mod.__rpc_calls__(), fn {name, _, _} = rpc ->
         func_name = name |> to_string |> Macro.underscore() |> String.to_atom()
         path = "/#{service_name}/#{name}"
         grpc_type = GRPC.Service.grpc_type(rpc)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GRPC.Mixfile do
   def project do
     [
       app: :grpc,
-      version: "0.6.4",
+      version: "0.6.5",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
It resolves this warning reported during compilation:
```
warning: using map.field notation (without parentheses) to invoke function Fresha.Waitlists.Protobuf.Rpc.V1.RPCService.Service.__rpc_calls__() is deprecated, you must add parentheses instead: remote.function()
  lib/waitlists_rpc/grpc/server.ex:6: (module)
  (elixir 1.17.1) src/elixir_compiler.erl:77: :elixir_compiler.dispatch/4
  (elixir 1.17.1) src/elixir_compiler.erl:52: :elixir_compiler.compile/4
  (elixir 1.17.1) src/elixir_module.erl:427: :elixir_module.eval_form/7
  (elixir 1.17.1) src/elixir_module.erl:129: :elixir_module.compile/7

Compilation failed due to warnings while using the --warnings-as-errors option
```