### PR TITLE
Use parentheses in GRPC.Stub to avoid warnings during compilation in …

### DIFF
--- a/lib/grpc/stub.ex
+++ b/lib/grpc/stub.ex
@@ -59,7 +59,7 @@ defmodule GRPC.Stub do
       service_mod = opts[:service]
       service_name = service_mod.__meta__(:name)
 
-      Enum.each(service_mod.__rpc_calls__, fn {name, {_, req_stream}, {_, res_stream}} = rpc ->
+      Enum.each(service_mod.__rpc_calls__(), fn {name, {_, req_stream}, {_, res_stream}} = rpc ->
         func_name = name |> to_string |> Macro.underscore()
         path = "/#{service_name}/#{name}"
         grpc_type = GRPC.Service.grpc_type(rpc)

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule GRPC.Mixfile do
   def project do
     [
       app: :grpc,
-      version: "0.6.5",
+      version: "0.6.6",
       elixir: "~> 1.5",
       elixirc_paths: elixirc_paths(Mix.env()),
       build_embedded: Mix.env() == :prod,


### PR DESCRIPTION
It resolves this warning reported during compilation:

```
warning: using map.field notation (without parentheses) to invoke function Rpc.LandingPagesManager.V1.RPCService.Service.__rpc_calls__() is deprecated, you must add parentheses instead: remote.function()
  lib/rpc/landing_pages_manager/v1/landing_pages_manager_service.pb.ex:56: (module)
  (elixir 1.17.3) src/elixir_compiler.erl:77: :elixir_compiler.dispatch/4
  (elixir 1.17.3) src/elixir_compiler.erl:52: :elixir_compiler.compile/4
  (elixir 1.17.3) src/elixir_module.erl:427: :elixir_module.eval_form/7
  (elixir 1.17.3) src/elixir_module.erl:129: :elixir_module.compile/7
```

This PR applies the same fix as #16 but in a different module.