### PR TITLE
chore: redirect actions to freshaengineering + pin to SHA

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,13 +1,13 @@
 version: 1
-generated_at: 2026-05-25T15:33:36Z
+generated_at: 2026-06-11T15:38:43Z
 internal: []
 trusted:
   - action: actions/checkout
     refs:
+      - 34e114876b0b11c390a56381ad16ebd13914f8d5
       - v1
-      - v4
     occurrences:
-      v4:
+      34e114876b0b11c390a56381ad16ebd13914f8d5:
         .github/workflows/ci.yml:
           - jobs.static.steps.[0].uses
           - jobs.test.steps.[0].uses
@@ -22,9 +22,9 @@ trusted:
           - jobs.interop-tests.steps.[0].uses
   - action: runs-on/cache
     refs:
-      - v4
+      - a5f51d6f3fece787d03b7b4e981c82538a0654ed
     occurrences:
-      v4:
+      a5f51d6f3fece787d03b7b4e981c82538a0654ed:
         .github/workflows/ci.yml:
           - jobs.static.steps.[4].uses
           - jobs.static.steps.[6].uses
@@ -32,16 +32,16 @@ trusted:
           - jobs.test.steps.[6].uses
   - action: runs-on/cache/restore
     refs:
-      - v4
+      - a5f51d6f3fece787d03b7b4e981c82538a0654ed
     occurrences:
-      v4:
+      a5f51d6f3fece787d03b7b4e981c82538a0654ed:
         .github/workflows/dev-publish.yaml:
           - jobs.dev-publish.steps.[2].uses
   - action: runs-on/cache/save
     refs:
-      - v4
+      - a5f51d6f3fece787d03b7b4e981c82538a0654ed
     occurrences:
-      v4:
+      a5f51d6f3fece787d03b7b4e981c82538a0654ed:
         .github/workflows/ci.yml:
           - jobs.permit.steps.[3].uses
 external:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         runner-os: [ubuntu20]
     steps:
       - name: Checkout latest codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ env.SHA }}
           clean: false
@@ -62,7 +62,7 @@ jobs:
           echo "HASH=$HASH" >> $GITHUB_OUTPUT
       - name: Hex auth
         run: mix hex.organization auth fresha --key ${{ secrets.HEX_ORGANIZATION_WRITE_KEY }}
-      - uses: runs-on/cache@v4
+      - uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
         id: deps-cache
         with:
           path: |
@@ -77,7 +77,7 @@ jobs:
           echo "Installing dependencies"
           mix deps.get
           mix deps.compile
-      - uses: runs-on/cache@v4
+      - uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
         id: build-cache
         with:
           path: '**/*'
@@ -108,7 +108,7 @@ jobs:
         runner-os: [ubuntu20]
     steps:
       - name: Checkout latest codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ env.SHA }}
           clean: false
@@ -131,7 +131,7 @@ jobs:
           echo "HASH=$HASH" >> $GITHUB_OUTPUT
       - name: Hex auth
         run: mix hex.organization auth fresha --key ${{ secrets.HEX_ORGANIZATION_WRITE_KEY }}
-      - uses: runs-on/cache@v4
+      - uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
         id: deps-cache
         with:
           path: |
@@ -146,7 +146,7 @@ jobs:
           echo "Installing dependencies"
           mix deps.get
           mix deps.compile
-      - uses: runs-on/cache@v4
+      - uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
         id: build-cache
         with:
           path: '**/*'
@@ -170,7 +170,7 @@ jobs:
       PUBLISH: ${{ steps.version.outputs.PUBLISH }}
     steps:
       - name: Checkout latest codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 2
           ref: ${{ env.SHA }}
@@ -207,7 +207,7 @@ jobs:
           echo ""
           echo "==============================================="
       - name: Cache Approval File
-        uses: runs-on/cache/save@v4
+        uses: runs-on/cache/save@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
         with:
           path: approval.txt
           key: ${{ runner.os }}-${{ env.REPOSITORY }}-approval-${{ needs.static.outputs.HASH }}
@@ -219,7 +219,7 @@ jobs:
     if: needs.permit.outputs.PUBLISH == 'true' && github.event_name == 'push'
     steps:
       - name: Checkout latest codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ env.SHA }}
           clean: false
@@ -255,7 +255,7 @@ jobs:
     container:
       image: elixir:1.10-slim
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Install Dependencies
       run: |
         mix local.rebar --force
@@ -272,7 +272,7 @@ jobs:
     container:
       image: elixir:1.10-slim
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Dependencies
         run: |
           mix local.rebar --force

--- a/.github/workflows/dev-publish.yaml
+++ b/.github/workflows/dev-publish.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: runs-on,runner=4cpu-linux-x64
     steps:
       - name: Checkout latest codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ env.sha }}
           clean: false
@@ -42,7 +42,7 @@ jobs:
           echo "APPROVAL PRODUCED BY SUCCESSFULL CHECKS EXECUTION WILL LAND IN CACHE"
           echo "HASH=$HASH" >> $GITHUB_OUTPUT
       - name: Check for CI successes
-        uses: runs-on/cache/restore@v4
+        uses: runs-on/cache/restore@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
         with:
           key: ${{ runner.os }}-${{ env.REPOSITORY }}-approval-${{ steps.hash.outputs.HASH }}
           path: approval.txt


### PR DESCRIPTION
## Summary
- Redirects all `surgeventures/platform-tribe-actions` references to `freshaengineering/platform-tribe-actions`
- Pins **all** GitHub Actions to immutable commit SHAs — both external third-party actions and internal `platform-tribe-actions` references

## How it was generated

The following 5 commands were run in sequence from the repository root:

```
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-bump-internal.js
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-pin-external.js --pin-all
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
```

- `actions-lockfile-produce.js` — generates/updates `.github/actions.lock.yaml` from current workflow refs
- `actions-lockfile-bump-internal.js` — resolves internal (`platform-tribe-actions`) action refs to their current SHA
- `actions-lockfile-pin-external.js --pin-all` — resolves all external action refs to their current SHA