### PR TITLE
chore: pin GitHub Actions to immutable commit SHAs

### DIFF
--- a/.github/actions.lock.yaml
+++ b/.github/actions.lock.yaml
@@ -1,11 +1,11 @@
 version: 1
-generated_at: 2026-06-11T15:38:43Z
+generated_at: 2026-06-15T13:15:24Z
 internal: []
 trusted:
   - action: actions/checkout
     refs:
       - 34e114876b0b11c390a56381ad16ebd13914f8d5
-      - v1
+      - 50fbc622fc4ef5163becd7fab6573eac35f8462e
     occurrences:
       34e114876b0b11c390a56381ad16ebd13914f8d5:
         .github/workflows/ci.yml:
@@ -17,7 +17,7 @@ trusted:
           - jobs.check_release.steps.[0].uses
         .github/workflows/dev-publish.yaml:
           - jobs.dev-publish.steps.[0].uses
-      v1:
+      50fbc622fc4ef5163becd7fab6573eac35f8462e:
         .github/workflows/cron_ci.yml:
           - jobs.interop-tests.steps.[0].uses
   - action: runs-on/cache

--- a/.github/workflows/cron_ci.yml
+++ b/.github/workflows/cron_ci.yml
@@ -11,7 +11,7 @@ jobs:
     container:
       image: elixir:1.9
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1
     - name: Install Dependencies
       run: |
         mix local.rebar --force


### PR DESCRIPTION
## Summary
- Pins **all** GitHub Actions to immutable commit SHAs — both external third-party actions and internal `platform-tribe-actions` references

## How it was generated

The following commands were run in sequence from the repository root:

```
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-bump-internal.js
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
node platform-tribe-actions/.scripts/actions-lockfile-pin-external.js --pin-all
node platform-tribe-actions/.scripts/actions-lockfile-produce.js
```

- `actions-lockfile-produce.js` — generates/updates `.github/actions.lock.yaml` from current workflow refs
- `actions-lockfile-bump-internal.js` — resolves internal (`platform-tribe-actions`) action refs to their current SHA
- `actions-lockfile-pin-external.js --pin-all` — resolves all external action refs to their current SHA