### PR TITLE
chore: replace runs-on/cache with the StepSecurity-maintained fork

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           echo "HASH=$HASH" >> $GITHUB_OUTPUT
       - name: Hex auth
         run: mix hex.organization auth fresha --key ${{ secrets.HEX_ORGANIZATION_WRITE_KEY }}
-      - uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
+      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
         id: deps-cache
         with:
           path: |
@@ -77,7 +77,7 @@ jobs:
           echo "Installing dependencies"
           mix deps.get
           mix deps.compile
-      - uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
+      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
         id: build-cache
         with:
           path: '**/*'
@@ -131,7 +131,7 @@ jobs:
           echo "HASH=$HASH" >> $GITHUB_OUTPUT
       - name: Hex auth
         run: mix hex.organization auth fresha --key ${{ secrets.HEX_ORGANIZATION_WRITE_KEY }}
-      - uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
+      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
         id: deps-cache
         with:
           path: |
@@ -146,7 +146,7 @@ jobs:
           echo "Installing dependencies"
           mix deps.get
           mix deps.compile
-      - uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
+      - uses: step-security/runs-on-cache@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
         id: build-cache
         with:
           path: '**/*'
@@ -207,7 +207,7 @@ jobs:
           echo ""
           echo "==============================================="
       - name: Cache Approval File
-        uses: runs-on/cache/save@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
+        uses: step-security/runs-on-cache/save@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
         with:
           path: approval.txt
           key: ${{ runner.os }}-${{ env.REPOSITORY }}-approval-${{ needs.static.outputs.HASH }}

--- a/.github/workflows/dev-publish.yaml
+++ b/.github/workflows/dev-publish.yaml
@@ -42,7 +42,7 @@ jobs:
           echo "APPROVAL PRODUCED BY SUCCESSFULL CHECKS EXECUTION WILL LAND IN CACHE"
           echo "HASH=$HASH" >> $GITHUB_OUTPUT
       - name: Check for CI successes
-        uses: runs-on/cache/restore@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
+        uses: step-security/runs-on-cache/restore@c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7
         with:
           key: ${{ runner.os }}-${{ env.REPOSITORY }}-approval-${{ steps.hash.outputs.HASH }}
           path: approval.txt


### PR DESCRIPTION
## What

Swaps all six `runs-on/cache*` references in this repo to the StepSecurity-maintained fork, pinned to the
sha the rest of the org already uses (`c5b0cba15d05488ebc630ad8d1e95b3d9b35ac73 # v5.0.7`):

| File | Line(s) | Old | New |
|---|---|---|---|
| `.github/workflows/ci.yml` | 65, 80, 134, 149 | `runs-on/cache@a5f51d6f` | `step-security/runs-on-cache@c5b0cba1` |
| `.github/workflows/ci.yml` | 210 | `runs-on/cache/save@a5f51d6f` | `step-security/runs-on-cache/save@c5b0cba1` |
| `.github/workflows/dev-publish.yaml` | 45 | `runs-on/cache/restore@a5f51d6f` | `step-security/runs-on-cache/restore@c5b0cba1` |

## Why

Part of the org-wide effort to move third-party GitHub Actions onto StepSecurity-maintained forks.

This repo is a **fork**, and GitHub code search does not index forks — so it was invisible to the earlier
sweeps. It is the last place in `freshaengineering` still calling `runs-on/cache`, `runs-on/cache/save` or
`runs-on/cache/restore` from a workflow.

## Why this is safe

- **The action contract is unchanged.** Diffing `action.yml`, `save/action.yml` and `restore/action.yml`
  between `runs-on/cache@a5f51d6f` and `step-security/runs-on-cache@c5b0cba1`, the only differing line in
  all three files is `author:`. Identical inputs, outputs and `runs.using: 'node24'` — no node jump. The
  `# v4` → `# v5.0.7` comment change is a label correction, not a behaviour change.
- **The RunsOn S3 cache backend is preserved.** Every job here runs on RunsOn runners
  (`runs-on,runner={1,2,4}cpu-linux-x64`), so the S3-backed cache path is load-bearing. The fork keeps
  `RUNS_ON_S3_BUCKET_CACHE` detection in `src/restoreImpl.ts` / `src/saveImpl.ts` **and** in the shipped
  `dist/` bundles, including the automatic fallback to GitHub's cache service.
- **Proven on the identical template.** Our sister Elixir fork `freshaengineering/libcluster` runs the same
  CI template and has been on `step-security/runs-on-cache@c5b0cba1 # v5.0.7` (root, `/save` and
  `/restore`) with green builds.
- **No subscription gate.** This repo is public, so the fork reports "Free for public repositories" rather
  than requiring a StepSecurity subscription.

Note we deliberately did *not* use the fork's `v4` tag: its `save/` and `restore/` are `node20`, which
would be a regression from the node24 currently pinned here.

## Notes

- `.github/actions.lock.yaml` is generated and **deliberately untouched**; it refreshes when its generator
  next runs, so it will keep naming `runs-on/cache` for a while. That is expected, not a failed swap — and
  it's why StepSecurity's dashboard lags behind.
- Open bot PR #28 ("[StepSecurity] Apply security best practices") touches the same two files but only
  inserts `harden-runner` steps — different hunks, no overlap with these lines. Whichever merges second may
  need a trivial rebase.
