### PR TITLE
[StepSecurity] Swap third-party actions to StepSecurity-maintained forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -275,11 +275,11 @@ jobs:
     container:
       image: elixir:1.10-slim
     steps:
-      - name: Harden the runner
-        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
-        with:
-          use-policy-store: true
-          api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
+    - name: Harden the runner
+      uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+      with:
+        use-policy-store: true
+        api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Install Dependencies
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           clean: false
           persist-credentials: true
       - name: Setup Elixir
-        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
+        uses: step-security/setup-beam@05e480cfdc64c72ab6c25b134dd1f57e29776c84 # v1.24.1
         env:
           ImageOS: ${{ matrix.runner-os }}
         with:
@@ -62,7 +62,7 @@ jobs:
           echo "HASH=$HASH" >> $GITHUB_OUTPUT
       - name: Hex auth
         run: mix hex.organization auth fresha --key ${{ secrets.HEX_ORGANIZATION_WRITE_KEY }}
-      - uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
+      - uses: step-security/runs-on-cache@e61ed9b0206c630e9a6bb5f12ca4cd78ae7bbe93 # v5.0.8
         id: deps-cache
         with:
           path: |
@@ -77,7 +77,7 @@ jobs:
           echo "Installing dependencies"
           mix deps.get
           mix deps.compile
-      - uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
+      - uses: step-security/runs-on-cache@e61ed9b0206c630e9a6bb5f12ca4cd78ae7bbe93 # v5.0.8
         id: build-cache
         with:
           path: '**/*'
@@ -114,7 +114,7 @@ jobs:
           clean: false
           persist-credentials: true
       - name: Setup Elixir
-        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
+        uses: step-security/setup-beam@05e480cfdc64c72ab6c25b134dd1f57e29776c84 # v1.24.1
         env:
           ImageOS: ${{ matrix.runner-os }}
         with:
@@ -131,7 +131,7 @@ jobs:
           echo "HASH=$HASH" >> $GITHUB_OUTPUT
       - name: Hex auth
         run: mix hex.organization auth fresha --key ${{ secrets.HEX_ORGANIZATION_WRITE_KEY }}
-      - uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
+      - uses: step-security/runs-on-cache@e61ed9b0206c630e9a6bb5f12ca4cd78ae7bbe93 # v5.0.8
         id: deps-cache
         with:
           path: |
@@ -146,7 +146,7 @@ jobs:
           echo "Installing dependencies"
           mix deps.get
           mix deps.compile
-      - uses: runs-on/cache@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
+      - uses: step-security/runs-on-cache@e61ed9b0206c630e9a6bb5f12ca4cd78ae7bbe93 # v5.0.8
         id: build-cache
         with:
           path: '**/*'
@@ -207,7 +207,7 @@ jobs:
           echo ""
           echo "==============================================="
       - name: Cache Approval File
-        uses: runs-on/cache/save@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
+        uses: step-security/runs-on-cache/save@e61ed9b0206c630e9a6bb5f12ca4cd78ae7bbe93 # v5.0.8
         with:
           path: approval.txt
           key: ${{ runner.os }}-${{ env.REPOSITORY }}-approval-${{ needs.static.outputs.HASH }}
@@ -225,7 +225,7 @@ jobs:
           clean: false
           persist-credentials: true
       - name: Setup Elixir
-        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
+        uses: step-security/setup-beam@05e480cfdc64c72ab6c25b134dd1f57e29776c84 # v1.24.1
         env:
           ImageOS: ${{ env.RUNNER_OS }}
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
         elixir: [1.10.4]
         runner-os: [ubuntu20]
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          use-policy-store: true
+          api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
       - name: Checkout latest codebase
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -107,6 +112,11 @@ jobs:
         elixir: [1.10.4]
         runner-os: [ubuntu20]
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          use-policy-store: true
+          api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
       - name: Checkout latest codebase
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -169,6 +179,11 @@ jobs:
     outputs:
       PUBLISH: ${{ steps.version.outputs.PUBLISH }}
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          use-policy-store: true
+          api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
       - name: Checkout latest codebase
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -218,6 +233,11 @@ jobs:
     runs-on: runs-on,runner=2cpu-linux-x64
     if: needs.permit.outputs.PUBLISH == 'true' && github.event_name == 'push'
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          use-policy-store: true
+          api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
       - name: Checkout latest codebase
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -255,6 +275,11 @@ jobs:
     container:
       image: elixir:1.10-slim
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          use-policy-store: true
+          api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
     - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     - name: Install Dependencies
       run: |
@@ -272,6 +297,11 @@ jobs:
     container:
       image: elixir:1.10-slim
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          use-policy-store: true
+          api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Install Dependencies
         run: |

--- a/.github/workflows/dev-publish.yaml
+++ b/.github/workflows/dev-publish.yaml
@@ -24,6 +24,11 @@ jobs:
     name: Dev Publish
     runs-on: runs-on,runner=4cpu-linux-x64
     steps:
+      - name: Harden the runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2
+        with:
+          use-policy-store: true
+          api-key: ${{ secrets.GH_FRESHAENGINEERING_STEP_SECURITY_API_KEY }}
       - name: Checkout latest codebase
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/dev-publish.yaml
+++ b/.github/workflows/dev-publish.yaml
@@ -42,13 +42,13 @@ jobs:
           echo "APPROVAL PRODUCED BY SUCCESSFULL CHECKS EXECUTION WILL LAND IN CACHE"
           echo "HASH=$HASH" >> $GITHUB_OUTPUT
       - name: Check for CI successes
-        uses: runs-on/cache/restore@a5f51d6f3fece787d03b7b4e981c82538a0654ed # v4
+        uses: step-security/runs-on-cache/restore@e61ed9b0206c630e9a6bb5f12ca4cd78ae7bbe93 # v5.0.8
         with:
           key: ${{ runner.os }}-${{ env.REPOSITORY }}-approval-${{ steps.hash.outputs.HASH }}
           path: approval.txt
           fail-on-cache-miss: true
       - name: Setup Elixir
-        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1
+        uses: step-security/setup-beam@05e480cfdc64c72ab6c25b134dd1f57e29776c84 # v1.24.1
         env:
           ImageOS: ${{ env.RUNNER_OS }}
         with:


### PR DESCRIPTION
Swaps third-party GitHub Actions to their StepSecurity-maintained forks, pinned to the fork's latest release SHA:

- `erlef/setup-beam` -> `step-security/setup-beam@05e480cfdc64` (v1.24.1)
- `runs-on/cache` -> `step-security/runs-on-cache@e61ed9b0206c` (v5.0.8)
- `runs-on/cache/restore` -> `step-security/runs-on-cache/restore@e61ed9b0206c` (v5.0.8)
- `runs-on/cache/save` -> `step-security/runs-on-cache/save@e61ed9b0206c` (v5.0.8)

- files changed: 2
- references swapped: 10

StepSecurity forks are drop-in replacements (same inputs/outputs) with security hardening and active maintenance. Part of the org-wide StepSecurity third-party-action migration (freshaengineering/team-devex#483).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
